### PR TITLE
fix issues & add options

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,25 +5,27 @@ const plugin = require('./babel-plugin.js');
 
 // Snowpack Plugin
 module.exports = function (snowpackConfig, pluginOptions) {
+  
+  const extensions = pluginOptions.extensions || ['.js', '.jsx','.tsx', '.ts']; // extensions.
+  const dev = pluginOptions.dev || false; // for debugging improvements in development.
+  const imports = pluginOptions.imports || {};
 
   return {
+    async transform(options) {
+      
+      const { contents, filePath, isDev, fileExt } = options;
 
-    // build source with babel
-    async build(options) {
-      const { contents, filePath, isDev } = options;
-
-      const result = await transformAsync(contents, {
-        filename: filePath,
-        plugins: [plugin(pluginOptions)],
-        cwd: process.cwd(),
-        ast: false,
-      });
-
-      let code = result.code;
-
-      return {
-        result: code,
+      if (!(isDev === true && dev === true) &&
+        extensions.includes(fileExt.toLowerCase())) {
+        const result = await transformAsync(contents, {
+          filename: filePath,
+          plugins: [plugin(imports)],
+          cwd: process.cwd(),
+          ast: false,
+        });
+        return result.code;
       }
+      return contents;
     },
   };
 };


### PR DESCRIPTION
## PR
Issue resolved (#2). 

## Changes
This PR handles two problems:
- Compatibility issue with latest snowpack
> - We cannot use both options `scripts` and `plugins` with same plugin anymore. So we must remove in `scripts`.
> - No more `build` method in snowpack plugin definition. The `transform`, it works exactly what we intended.
https://www.snowpack.dev/plugins
https://github.com/pikapkg/snowpack/blob/master/snowpack/src/types/snowpack.ts#L69

However, only fixing this problem cannot prevent losing exts due to removing `scripts` in config. 
**Thus, below changes comes with it.**

- Losing extension due to removing `scripts` in config
> Put `scripts` config into `plugins` option to handle issue that I mentioned above.
Therefore, this PR cause some changes in configuration due to handle various plugin options: `extension`, `dev`, `imports`.

configuration example(new): 
``` js
module.exports = {
  "extends": "@snowpack/app-scripts-react",
  "plugins": [
    ['snowpack-plugin-import-map', 
    {
      dev: true, // if true, import-map transforms imports in development mode too. default: false.
      extensions: ['.js', '.jsx','.tsx', '.ts'], // supported extensions. default: ['.js', '.jsx','.tsx', '.ts']
      imports: { // map of packages.
        react: 'https://cdn.pika.dev/react@^16.13.1',
        'react-dom': 'https://cdn.pika.dev/react-dom@^16.13.1',
      }
    }]]
}

```

configuration example(previous):
``` js
module.exports = {
  "extends": "@snowpack/app-scripts-react",
  "scripts": {
    "build:js,jsx,ts,tsx": 'snowpack-plugin-import-map'
  },
  "plugins": [
    ['snowpack-plugin-import-map', {
      react: 'https://cdn.pika.dev/react@^16.13.1',
      'react-dom': 'https://cdn.pika.dev/react-dom@^16.13.1',
    }]]
}
```