### PR TITLE
Add custom cdn url builder support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ module.exports = {
         dev: true,
         // supported extensions. default: ['.js', '.jsx','.tsx', '.ts']
         extensions: [".js", ".jsx", ".tsx", ".ts"],
+        // use custom cdn URL builder instead of Skypack.
+        getCdnURL: (source, version, isDev) => `https://cdnjs.cloudflare.com/ajax/libs/${source}/${version.replace(/[^\d.]/g, '')}/umd/${source}.production${isDev ? ".min" : ""}.js`
       },
     ],
   ],

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ module.exports = function (snowpackConfig, pluginOptions) {
   // Check if pluginOptions.getCdnURL is function
   let buildCdnURL = getSkypackCdnURL
 
-  if (typeof pluginOptions.getCdnURL === 'function') {
+  if (typeof pluginOptions.getCdnURL === "function") {
     buildCdnURL = pluginOptions.getCdnURL
   }
 

--- a/index.js
+++ b/index.js
@@ -33,6 +33,13 @@ module.exports = function (snowpackConfig, pluginOptions) {
   // Store package versions so the version is only resolved once
   const cache = new Map();
 
+  // Check if pluginOptions.getCdnURL is function
+  let buildCdnURL = getSkypackCdnURL
+
+  if (typeof pluginOptions.getCdnURL === 'function') {
+    buildCdnURL = pluginOptions.getCdnURL
+  }
+
   return {
     name: "snowpack-plugin-import-map",
     async transform({ contents, isDev, fileExt }) {
@@ -40,7 +47,7 @@ module.exports = function (snowpackConfig, pluginOptions) {
         contents = contents.replace(
           esmImportRegex,
           (_, before, source, after) => {
-            const newSource = rewriteImport(source, imports, cache, isDev);
+            const newSource = rewriteImport(source, imports, cache, isDev, buildCdnURL);
             return `${before}${newSource}${after}`;
           }
         );
@@ -50,7 +57,7 @@ module.exports = function (snowpackConfig, pluginOptions) {
   };
 };
 
-function rewriteImport(source, imports, cache, isDev) {
+function rewriteImport(source, imports, cache, isDev, buildCdnURL) {
   if (imports.hasOwnProperty(source)) {
     if (typeof imports[source] === "string") {
       // If the import option is a string, rewrite the import to be the string value
@@ -63,18 +70,25 @@ function rewriteImport(source, imports, cache, isDev) {
         return cached;
       }
 
-      let version = getVersionForPackage(source);
-      if (version) {
-        version = `@${version}`;
-      }
-      const cdnUrl = `https://cdn.skypack.dev/${source}${version}${
-        isDev ? "" : "?min"
-      }`;
+      const version = getVersionForPackage(source);
+      const cdnUrl = buildCdnURL(source, version, isDev);
+
       cache.set(source, cdnUrl);
+
       return cdnUrl;
     }
   }
   return source;
+}
+
+function getSkypackCdnURL(source, version, isDev) {
+  if (version) {
+    version = `@${version}`;
+  }
+
+  return `https://cdn.skypack.dev/${source}${version}${
+    isDev ? "" : "?min"
+  }`;
 }
 
 function getVersionForPackage(source) {

--- a/index.test.js
+++ b/index.test.js
@@ -118,16 +118,16 @@ test("runs in development mode with dev option set", async () => {
 });
 
 test("executes custom getCdnURL function properly", async () => {
-  const getCdnURL = (source, version, isDev) => `https://cdnjs.cloudflare.com/ajax/libs/${source}/${version.replace(/[^\d.]/g, '')}/umd/${source}.production${isDev ? ".min" : ""}.js`
+  const getCdnURL = (source, version, isDev) => `https://cdnjs.cloudflare.com/ajax/libs/${source}/${version.replace(/[^\d.]/g, "")}/umd/${source}.production${isDev ? ".min" : ""}.js`
   const expectedCustom = ({
     min = true,
-    isNumber = getCdnURL('is-number', isNumberVersion, !min),
+    isNumber = getCdnURL("is-number"), isNumberVersion, !min),
   } = {}) => `
 import isNumber from "${isNumber}";
 import React from "react";
 console.log(isNumber("5"));
 `;
-  const instance = plugin({}, { imports: { 'is-number': true }, getCdnURL })
+  const instance = plugin({}, { imports: { "is-number": true }, getCdnURL })
   const result = await instance.transform({
     contents,
     fileExt

--- a/index.test.js
+++ b/index.test.js
@@ -117,6 +117,24 @@ test("runs in development mode with dev option set", async () => {
   expect(result2).toEqual(expected({ min: false }));
 });
 
+test("executes custom getCdnURL function properly", async () => {
+  const getCdnURL = (source, version, isDev) => `https://cdnjs.cloudflare.com/ajax/libs/${source}/${version.replace(/[^\d.]/g, '')}/umd/${source}.production${isDev ? ".min" : ""}.js`
+  const expectedCustom = ({
+    min = true,
+    isNumber = getCdnURL('is-number', isNumberVersion, !min),
+  } = {}) => `
+import isNumber from "${isNumber}";
+import React from "react";
+console.log(isNumber("5"));
+`;
+  const instance = plugin({}, { imports: { 'is-number': true }, getCdnURL })
+  const result = await instance.transform({
+    contents,
+    fileExt
+  })
+  expect(result).toEqual(expectedCustom())
+})
+
 test("regex", () => {
   const shouldPass = `
     import defaultExport from "module-name";


### PR DESCRIPTION
This pull request adds #6 custom cdn url builder function support. However, I am new to testing utility and not sure if I wrote test code correctly. Please, check the test code if possible.

## Usage (preview README.md changes)

```js
module.exports = {
  extends: "@snowpack/app-scripts-react",
  plugins: [
    [
      "snowpack-plugin-import-map",
      {
        ...
        // use custom cdn URL builder instead of Skypack.
        getCdnURL: (source, version, isDev) => `https://cdnjs.cloudflare.com/ajax/libs/${source}/${version.replace(/[^\d.]/g, '')}/umd/${source}.production${isDev ? ".min" : ""}.js`
      },
    ],
  ],
};
```